### PR TITLE
Make 'with:' type more permissive

### DIFF
--- a/packages/cdkactions/src/job.ts
+++ b/packages/cdkactions/src/job.ts
@@ -86,7 +86,7 @@ export interface StepsProps extends RunProps {
   /**
    * A map of parameters for an external action.
    */
-  readonly with?: StringMap;
+  readonly with?: { [key: string]: string | number | boolean };
 
   /**
    * Additional environment variables.

--- a/packages/cdkactions/test/__snapshots__/job.test.ts.snap
+++ b/packages/cdkactions/test/__snapshots__/job.test.ts.snap
@@ -11,6 +11,15 @@ Object {
       "timeout-minutes": 5,
       "working-directory": "~/",
     },
+    Object {
+      "name": "External action",
+      "uses": "actions/checkout@v2",
+      "with": Object {
+        "booleanValue": false,
+        "numberValue": 10,
+        "stringValue": "string",
+      },
+    },
   ],
   "strategy": Object {
     "fail-fast": true,

--- a/packages/cdkactions/test/job.test.ts
+++ b/packages/cdkactions/test/job.test.ts
@@ -14,6 +14,15 @@ test('toGHAction', () => {
       continueOnError: false,
       timeoutMinutes: 5,
       workingDirectory: '~/',
+    },
+    {
+      name: 'External action',
+      uses: 'actions/checkout@v2',
+      with: {
+        stringValue: 'string',
+        numberValue: 10,
+        booleanValue: false,
+      },
     }],
   });
   expect(job.toGHAction()).toMatchSnapshot();


### PR DESCRIPTION
This PR changes the `with:` field within a job step to permit a map from `string` to `string | number | boolean`. The previous behavior only accepted a string to string map.

Fixes #7.